### PR TITLE
curl follows links for openssl

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -22,7 +22,7 @@ export DEBIAN_FRONTEND=noninteractive \
 export DEBIAN_FRONTEND=noninteractive \
     && mkdir openssl \
     && cd openssl \
-    && curl https://www.openssl.org/source/openssl-1.1.1k.tar.gz -o openssl.tar.gz \
+    && curl -L https://www.openssl.org/source/openssl-1.1.1k.tar.gz -o openssl.tar.gz \
     && echo "892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5  openssl.tar.gz" > sha256sums \
     && sha256sum -c sha256sums \
     && tar --strip-components=1 -xf openssl.tar.gz \


### PR DESCRIPTION
Because the original URL is a 301 redirect to Github now (at least for me it is?), `make image` fails without this. 